### PR TITLE
3. ページ全体の設定を追加 #3

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,28 @@
  *= require_tree .
  *= require_self
  */
+
+/* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-sm {
+  max-width: 576px;
+}
+
+.mw-md {
+  max-width: 768px;
+}
+
+.mw-lg {
+  max-width: 992px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def max_width
+    if controller_name == "texts" && action_name == "show"
+      "mw-md"
+    # Devise 導入後にコメントアウトを解除
+    # elsif devise_controller?
+    #  "mw-sm"
+    else
+      "mw-xl"
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,14 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <%= yield %>
+    <header>
+    </header>
+    <main>
+      <div class="base-container <%= max_width %>">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
close #3

## 実装内容

- ページ全体に共通する内容が書かれているファイル `app/views/layouts/application.html.erb` の

    `<%= yield %>`
を

```
    <header>
    </header>
    <main>
      <%# max_width メソッドは application_helper.rb に記載 %>
      <div class="base-container <%= max_width %>">
        <%= yield %>
      </div>
    </main>
    <footer>
    </footer>
```
としておき，全ページに共通して必要なCSSを `app/assets/stylesheets/application.css` に設定して下さい。

```
/*
 *= require_tree .
 *= require_self
 */

/* 全体 */ 

.base-container {
  margin: 0 auto;
  padding: 1rem;
}

/* max-width */ 

.mw-sm {
  max-width: 576px;
}

.mw-md {
  max-width: 768px;
}

.mw-lg {
  max-width: 992px;
}

.mw-xl {
  max-width: 1200px;
}
```
さらに，全体の横幅を設定する `max_width` メソッドを `app/helpers/application_helper.rb` に定義しましょう。

（`devise_controller?` の箇所は `Devise` 導入時に有効化します）

```
module ApplicationHelper
  def max_width
    if controller_name == "texts" && action_name == "show"
      "mw-md"
    # Devise 導入後にコメントアウトを解除
    # elsif devise_controller?
    #  "mw-sm"
    else
      "mw-xl"
    end
  end
end
```

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] `bundle exec rubocop -a` を実行