### PR TITLE
15. Rails動画教材ページの実装 #27

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,5 @@
+.movie-image iframe {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  height: 100%;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      # width: 560,
+      # height: 315,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+    )
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -13,4 +13,6 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,11 @@
+<div class="col-12 col-md-6 col-lg-4 text-item__container">
+  <div class="card text-item">
+    <div class="movie-image">
+      <%= embed_youtube( movie.url ) %>
+    </div>
+    <div class="card-body">
+      <a href="#" class="btn btn-secondary text-list__button">読破済みにする</a>
+      <p class="text-list__title">Lv.<%= movie_counter + 1 %> : <%= movie.title %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,1 +1,8 @@
-
+<div class="text-center">
+  <h1>Ruby/Rails 動画</h1>
+</div>
+<div class="container">
+  <div class="row">
+    <%= render @movies %>
+  </div>
+</div>


### PR DESCRIPTION
close #27

## 実装内容

- `app/models/movie.rb` に次を定義

```
  RAILS_GENRE_LIST = %w[basic git ruby rails]
```

- Rails動画教材の一覧ページを作成
  - 表示するジャンルは `Movie::RAILS_GENRE_LIST` に制限
  - Bootstrapの `Cards` や `Grid System` を用いて下図のようなスタイルにすること
  - each を使わず「[コレクションをレンダリング](https://railsguides.jp/layouts_and_rendering.html#%E3%82%B3%E3%83%AC%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%81%99%E3%82%8B)」を利用しましょう
  - 各動画にレベル表示を入れること（`rails collection index` などで検索）
  - カードの下側部分に `height` を指定して揃えること
  - 動画教材ページでしか利用しないスタイルは `app/assets/stylesheets/movies.scss` を作成して書き込むこと
  - 広告は実装しない
  - ページネーションは別タスクとする
  - 「視聴済みボタン」はボタンの配置のみとする。（機能は別タスクで実装）

![image](https://user-images.githubusercontent.com/89111327/174461344-c32099bc-3b82-447f-b245-afb16abe5dd0.png)
![image](https://user-images.githubusercontent.com/89111327/174461349-50f72fa5-f149-44e2-a1e2-547073545f13.png)
![image](https://user-images.githubusercontent.com/89111327/174461352-f73447ba-046f-423d-a20f-03b0ac42a11f.png)

## 参考文献

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
- [【公式】Embeds](https://getbootstrap.com/docs/4.5/utilities/embed/)
- [【やんばるエキスパート教材】YouTube動画の投稿](https://www.yanbaru-code.com/texts/349)

## 確認内容

- 画像のようにレスポンシブ対応ができているかどうかを確認
- カードの高さが一定になっているか確認
- PHPの動画教材が表示されていないことを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行