### PR TITLE
18. 動画教材ページのジャンル分け #30

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,9 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = if params[:genre] == "php"
+                Movie.where(genre: Movie::PHP_GENRE_LIST)
+              else
+                Movie.where(genre: Movie::RAILS_GENRE_LIST)
+              end
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,14 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = if params[:genre] == "php"
-                Movie.where(genre: Movie::PHP_GENRE_LIST)
-              else
-                Movie.where(genre: Movie::RAILS_GENRE_LIST)
-              end
-    @title = if params[:genre] == "php"
-               "PHP 動画"
-             else
-               "Ruby/Rails 動画"
-             end
+    @movies = Movie.genre(params)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -5,5 +5,10 @@ class MoviesController < ApplicationController
               else
                 Movie.where(genre: Movie::RAILS_GENRE_LIST)
               end
+    @title = if params[:genre] == "php"
+               "PHP 動画"
+             else
+               "Ruby/Rails 動画"
+             end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def movies_heading
+    if params[:genre] == "php"
+      "PHP 動画"
+    else
+      "Ruby/Rails 動画"
+    end
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,5 +15,5 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
-  PHP_GENRE_LIST = %w[basic git php].freeze
+  PHP_GENRE_LIST = %w[php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,4 +15,5 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[basic git php].freeze
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -15,5 +15,12 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
-  PHP_GENRE_LIST = %w[php].freeze
+
+  def self.genre(params)
+    if params[:genre] == "php"
+      Movie.where(genre: "php")
+    else
+      Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <h1><%= @title %></h1>
+  <h1><%= movies_heading %></h1>
 </div>
 <div class="container">
   <div class="row">

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <h1>Ruby/Rails 動画</h1>
+  <h1><%= @title %></h1>
 </div>
 <div class="container">
   <div class="row">


### PR DESCRIPTION
close #30

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正
  - `PHP動画教材` のリンクをクリックした際のクエリパラメータ `?genre=php` を利用
  - モデルにクラスメソッドを作成して対応できるとなおよいでしょう
- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする
  - `app/helpers/application_helper.rb` にメソッドを作成して対応できるとなおよいでしょう

## 確認内容

- 「Ruby/Rails動画教材」に「PHP動画」が含まれていないことを確認
- 「PHP動画教材」に「PHP動画」のみが表示されていることを確認
- クエリパラメータ `?genre=php を php` 以外に変更してアクセスした際は「Ruby/Rails動画教材」が表示されることを確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行