### PR TITLE
20. テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.genre(params)
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.genre(params)
+    @texts = Text.search_by_genre(params[:genre])
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,4 +16,12 @@ module ApplicationHelper
       "Ruby/Rails 動画"
     end
   end
+
+  def texts_heading
+    if params[:genre] == "php"
+      "PHPテキスト教材"
+    else
+      "Ruby/Railsテキスト教材"
+    end
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -15,4 +15,12 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  def self.genre(params)
+    if params[:genre] == "php"
+      Text.where(genre: "php")
+    else
+      Text.where(genre: Text::RAILS_GENRE_LIST)
+    end
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -16,8 +16,8 @@ class Text < ApplicationRecord
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
-  def self.genre(params)
-    if params[:genre] == "php"
+  def self.search_by_genre(genre)
+    if genre == "php"
       Text.where(genre: "php")
     else
       Text.where(genre: Text::RAILS_GENRE_LIST)

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="text-center">
-  <h1>Ruby/Rails テキスト教材</h1>
+  <h1><%= texts_heading %></h1>
 </div>
 <div class="container">
   <div class="row">


### PR DESCRIPTION
close #25  #30  完了後に行って下さい

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正

- PHPテキスト教材 のリンクをクリックした際のクエリパラメータ```?genre=php``` を利用

- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする

- 「タスク18」の ```app/helpers/application_helper.rb``` にメソッドを利用して対応


## 確認内容

- 「Ruby/Railsテキスト教材」に「PHPテキスト教材」が含まれていないことを確認

- 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認

- クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

