### PR TITLE
22. テキスト教材の読破済み機能

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - 'node_modules/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
+    - 'app/controllers/users/*'
 
 # 日本語のコメントを許可
 Style/AsciiComments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,6 @@ AllCops:
     - 'node_modules/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-    - 'app/controllers/users/*'
 
 # 日本語のコメントを許可
 Style/AsciiComments:
@@ -54,6 +53,10 @@ Rails/Output:
 Rails/FilePath:
   Exclude:
     - 'config/environments/development.rb'
+
+Rails/I18nLocaleTexts:
+  Exclude:
+    - 'app/controllers/users/sessions_controller.rb'
 
 Rails/OutputSafety:
   Exclude:

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.includes(:read_progresses).search_by_genre(params[:genre])
   end
 
   def show

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,8 @@
-class Users::SessionsController < Devise::SessionsController
-  def guest_sign_in
-    sign_in User.guest
-    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+module Users
+  class SessionsController < Devise::SessionsController
+    def guest_sign_in
+      sign_in User.guest
+      redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+    end
   end
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,2 @@
+class ReadProgress < ApplicationRecord
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -4,6 +4,6 @@ class ReadProgress < ApplicationRecord
 
   validates :user_id, uniqueness: {
     scope: :text_id,
-    message: "は同じテキスト教材を2回以上読破済みにはできません"
+    message: :read_twice
   }
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,2 +1,9 @@
 class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+
+  validates :user_id, uniqueness: {
+    scope: :text_id,
+    message: "は同じテキスト教材を2回以上読破済みにはできません"
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,5 @@
 class Text < ApplicationRecord
+  has_many :read_progresses, dependent: :destroy
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -16,4 +16,8 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  def read_finished?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -18,6 +18,14 @@ class Text < ApplicationRecord
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 
   def read_finished?(user)
-    read_progresses.exists?(user_id: user.id)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
+  end
+
+  def self.search_by_genre(genre)
+    if genre == "php"
+      Text.where(genre: "php")
+    else
+      Text.where(genre: Text::RAILS_GENRE_LIST)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
+  has_many :read_progresses, dependent: :destroy
 
   def self.guest
     find_or_create_by!(email: "test@example.com") do |user|

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%=@text.id%>').innerHTML = '<%= j render("texts/finished", text: @text) %>'

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%=@text.id%>').innerHTML = '<%= j render("texts/unfinished", text: @text) %>'

--- a/app/views/texts/_finished.html.erb
+++ b/app/views/texts/_finished.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除",text_read_progresses_path(text),class:"btn btn-primary text-list__button",method: :delete,remote: true%>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -3,11 +3,14 @@
     <div class="card text-item">
       <%= image_tag("default_image.jpeg")  %>
       <div class="card-body">
-      <% if text.read_finished?(current_user)%>
-        <%= render "finished",text: text%>
-      <% else%>
-        <%= render "unfinished",text: text%>
-      <% end %>
+      
+      <p id="text-<%= text.id%>">
+        <% if text.read_finished?(current_user)%>
+          <%= render "finished",text: text%>
+        <% else%>
+          <%= render "unfinished",text: text%>
+        <% end %>
+      </p>
         <p class="text-list__title"><%= text.title %></p>
         <p>【Basic】</p>
       </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -3,7 +3,11 @@
     <div class="card text-item">
       <%= image_tag("default_image.jpeg")  %>
       <div class="card-body">
-        <a href="#" class="btn btn-secondary text-list__button">読破済みにする</a>
+      <% if text.read_finished?(current_user)%>
+        <%= link_to "読破済みを解除",text_read_progresses_path(text),class:"btn btn-primary text-list__button",method: :delete%>
+      <% else%>
+        <%= link_to "読破済みにする",text_read_progresses_path(text),class:"btn btn-secondary text-list__button",method: :post%>
+      <% end %>
         <p class="text-list__title"><%= text.title %></p>
         <p>【Basic】</p>
       </div>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -4,9 +4,9 @@
       <%= image_tag("default_image.jpeg")  %>
       <div class="card-body">
       <% if text.read_finished?(current_user)%>
-        <%= link_to "読破済みを解除",text_read_progresses_path(text),class:"btn btn-primary text-list__button",method: :delete%>
+        <%= render "finished",text: text%>
       <% else%>
-        <%= link_to "読破済みにする",text_read_progresses_path(text),class:"btn btn-secondary text-list__button",method: :post%>
+        <%= render "unfinished",text: text%>
       <% end %>
         <p class="text-list__title"><%= text.title %></p>
         <p>【Basic】</p>

--- a/app/views/texts/_unfinished.html.erb
+++ b/app/views/texts/_unfinished.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする",text_read_progresses_path(text),class:"btn btn-secondary text-list__button",method: :post,remote: true%>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,3 +27,5 @@ ja:
       read_progress:
         user: ユーザー
         text: テキスト教材
+      message:
+        duplication_read: 'は同じテキスト教材を2回以上読破済みにはできません'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
       movie: 動画教材
       admin_user: 管理者ユーザー
       comment: コメント
+      read_progress: 読破済み
     attributes:
       text:
         genre: ジャンル
@@ -23,3 +24,6 @@ ja:
       admin_user:
         email: Eメール
         created_at: 作成日時
+      read_progress:
+        user: ユーザー
+        text: テキスト教材

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,6 @@ ja:
       movie: 動画教材
       admin_user: 管理者ユーザー
       comment: コメント
-      read_progress: 読破済み
     attributes:
       text:
         genre: ジャンル
@@ -27,5 +26,6 @@ ja:
       read_progress:
         user: ユーザー
         text: テキスト教材
-      message:
-        duplication_read: 'は同じテキスト教材を2回以上読破済みにはできません'
+  errors:
+    messages:
+      read_twice: 'は同じテキスト教材を2回以上読破済みにはできません'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
   root to: "texts#index"
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index]
 end

--- a/db/migrate/20220722065113_create_read_progresses.rb
+++ b/db/migrate/20220722065113_create_read_progresses.rb
@@ -1,0 +1,10 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :read_progresses, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_24_164412) do
+ActiveRecord::Schema.define(version: 2022_07_22_065113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2022_06_24_164412) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2022_06_24_164412) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #44 

## 実装内容

- 読破済み機能に使用する ReadProgress モデルを作成

- 外部キー設定を行い，ユニーク制約を入れてからマイグレーション

- バリデーションをモデルに追加

- 関連付けを入れる（User と Text の関連付けは使用しないので入れなくてもOK）

- 初期データの実装は不要

- テキスト教材一覧ページに読破済み機能を実装

- 非同期で処理できるように実装

## 確認内容

- 以下を確認

```
rails c -s
# Railsコンソール起動後
user = User.first
text, text2 = Text.limit(2)
ReadProgress.delete_all

user.read_progresses.create!(text_id: text.id)
user.read_progresses.create!(text_id: text2.id)

ReadProgress.count
#=> 2

text.read_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じテキスト教材を2回以上読破済みにはできません

ReadProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, テキスト教材を入力してください
```

- テキスト教材一覧ページの読破済み機能が動作していることを確認

## 参考資料

【やんばるエキスパート教材】モデルの関連付け その2（多対多）```https://www.yanbaru-code.com/texts/297```

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

